### PR TITLE
Enforce MindViz CSS variables

### DIFF
--- a/dist/styles.d.ts
+++ b/dist/styles.d.ts
@@ -83,6 +83,7 @@ export declare const createButton: (variant?: "primary" | "secondary" | "danger"
     disableHoverEffect?: boolean;
 }) => HTMLButtonElement;
 export declare const extractSolidColor: (bg: string) => string | null;
+export declare const enforceCssVars: () => void;
 export declare const injectGlobalStyles: () => void;
 export declare const animateElement: (element: HTMLElement, animation: string, duration?: number) => Promise<void>;
 export declare const createLoadingSpinner: (size?: number) => HTMLElement;

--- a/dist/styles.js
+++ b/dist/styles.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.createToast = exports.createLoadingSpinner = exports.animateElement = exports.injectGlobalStyles = exports.extractSolidColor = exports.createButton = exports.createInput = exports.createBaseElement = exports.CSS_VARS = void 0;
+exports.createToast = exports.createLoadingSpinner = exports.animateElement = exports.injectGlobalStyles = exports.enforceCssVars = exports.extractSolidColor = exports.createButton = exports.createInput = exports.createBaseElement = exports.CSS_VARS = void 0;
 exports.CSS_VARS = {
     // Primary colors with enhanced gradients
     primary: 'var(--mm-primary, #4dabf7)',
@@ -277,8 +277,55 @@ const extractSolidColor = (bg) => {
     return match ? match[0] : null;
 };
 exports.extractSolidColor = extractSolidColor;
+// Force default MindViz CSS variables on the :root element
+const enforceCssVars = () => {
+    if (typeof document === 'undefined')
+        return;
+    const root = document.documentElement;
+    if (root.hasAttribute('data-mm-vars-injected'))
+        return;
+    root.setAttribute('data-mm-vars-injected', 'true');
+    const vars = {
+        '--mm-primary': '#4dabf7',
+        '--mm-primary-hover': '#339af7',
+        '--mm-primary-light': '#e3f2fd',
+        '--mm-primary-dark': '#1976d2',
+        '--mm-secondary': '#6c757d',
+        '--mm-accent': '#ff9800',
+        '--mm-success': '#28a745',
+        '--mm-warning': '#ffc107',
+        '--mm-danger': '#ff6b6b',
+        '--mm-danger-hover': '#c82333',
+        '--mm-bg': '#ffffff',
+        '--mm-bg-secondary': '#f8f9fa',
+        '--mm-bg-tertiary': '#e9ecef',
+        '--mm-text': '#495057',
+        '--mm-text-secondary': '#6c757d',
+        '--mm-text-light': '#adb5bd',
+        '--mm-text-dark': '#212529',
+        '--mm-node-text': '#000000',
+        '--mm-border': '#e9ecef',
+        '--mm-border-light': '#f1f3f4',
+        '--mm-input-bg': '#ffffff',
+        '--mm-input-text': '#495057',
+        '--mm-input-border': '#e9ecef',
+        '--mm-input-focus': '#4dabf7',
+        '--mm-toolbar-bg': 'rgba(248, 250, 252, 0.95)',
+        '--mm-grid-color': 'rgba(200, 200, 200, 0.3)',
+        '--mm-grid-major-color': 'rgba(150, 150, 150, 0.5)',
+        '--mm-connection-color': '#ced4da',
+        '--mm-modal-bg': '#ffffff',
+        '--mm-modal-text': '#2d3436',
+        '--mm-modal-border': '#e0e0e0'
+    };
+    for (const [key, value] of Object.entries(vars)) {
+        root.style.setProperty(key, value, 'important');
+    }
+};
+exports.enforceCssVars = enforceCssVars;
 // Global CSS animations
 const injectGlobalStyles = () => {
+    (0, exports.enforceCssVars)();
     const style = document.createElement('style');
     style.textContent = `
 		@keyframes ripple {

--- a/dist/visualMindmap.js
+++ b/dist/visualMindmap.js
@@ -1738,27 +1738,27 @@ class VisualMindMap {
         root.setAttribute('data-theme', this.theme);
         if (this.theme === 'dark') {
             // Dark theme colors
-            root.style.setProperty("--mm-container-bg", "#0f172a");
-            root.style.setProperty("--mm-bg", "#1e293b");
-            root.style.setProperty("--mm-text", "#f1f5f9");
-            root.style.setProperty("--mm-node-bg", "#334155");
-            root.style.setProperty("--mm-node-text", "#ffffff");
-            root.style.setProperty("--mm-node-border-color", "#475569");
-            root.style.setProperty("--mm-description-bg", "#1e293b");
-            root.style.setProperty("--mm-description-text", "#cbd5e1");
-            root.style.setProperty("--mm-primary", "#60a5fa");
-            root.style.setProperty("--mm-primary-hover", "#3b82f6");
-            root.style.setProperty("--mm-primary-light", "rgba(96, 165, 250, 0.1)");
-            root.style.setProperty("--mm-border", "#475569");
-            root.style.setProperty("--mm-border-light", "#374151");
-            root.style.setProperty("--mm-connection-color", "#64748b");
-            root.style.setProperty("--mm-highlight", "#60a5fa");
-            root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.4)");
-            root.style.setProperty("--mm-toolbar-bg", "rgba(30, 41, 59, 0.95)");
-            root.style.setProperty("--mm-modal-bg", "#1e293b");
-            root.style.setProperty("--mm-modal-border", "#475569");
-            root.style.setProperty("--mm-primary-dark", "#4dabf740");
-            root.style.setProperty("--mm-border-dark", "#5e5e5e");
+            root.style.setProperty("--mm-container-bg", "#0f172a", "important");
+            root.style.setProperty("--mm-bg", "#1e293b", "important");
+            root.style.setProperty("--mm-text", "#f1f5f9", "important");
+            root.style.setProperty("--mm-node-bg", "#334155", "important");
+            root.style.setProperty("--mm-node-text", "#ffffff", "important");
+            root.style.setProperty("--mm-node-border-color", "#475569", "important");
+            root.style.setProperty("--mm-description-bg", "#1e293b", "important");
+            root.style.setProperty("--mm-description-text", "#cbd5e1", "important");
+            root.style.setProperty("--mm-primary", "#60a5fa", "important");
+            root.style.setProperty("--mm-primary-hover", "#3b82f6", "important");
+            root.style.setProperty("--mm-primary-light", "rgba(96, 165, 250, 0.1)", "important");
+            root.style.setProperty("--mm-border", "#475569", "important");
+            root.style.setProperty("--mm-border-light", "#374151", "important");
+            root.style.setProperty("--mm-connection-color", "#64748b", "important");
+            root.style.setProperty("--mm-highlight", "#60a5fa", "important");
+            root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.4)", "important");
+            root.style.setProperty("--mm-toolbar-bg", "rgba(30, 41, 59, 0.95)", "important");
+            root.style.setProperty("--mm-modal-bg", "#1e293b", "important");
+            root.style.setProperty("--mm-modal-border", "#475569", "important");
+            root.style.setProperty("--mm-primary-dark", "#4dabf740", "important");
+            root.style.setProperty("--mm-border-dark", "#5e5e5e", "important");
             // Update canvas background
             this.container.style.backgroundColor = "#0f172a";
             this.container.style.color = "#f1f5f9";
@@ -1771,27 +1771,27 @@ class VisualMindMap {
         }
         else {
             // Light theme colors
-            root.style.setProperty("--mm-container-bg", "#ffffff");
-            root.style.setProperty("--mm-bg", "#f8fafc");
-            root.style.setProperty("--mm-text", "#1e293b");
-            root.style.setProperty("--mm-node-bg", "#ffffff");
-            root.style.setProperty("--mm-node-text", "#000000");
-            root.style.setProperty("--mm-node-border-color", "#e2e8f0");
-            root.style.setProperty("--mm-description-bg", "#f8fafc");
-            root.style.setProperty("--mm-description-text", "#64748b");
-            root.style.setProperty("--mm-primary", "#4dabf7");
-            root.style.setProperty("--mm-primary-hover", "#339af7");
-            root.style.setProperty("--mm-primary-light", "rgba(77, 171, 247, 0.1)");
-            root.style.setProperty("--mm-border", "#e2e8f0");
-            root.style.setProperty("--mm-border-light", "#f1f5f9");
-            root.style.setProperty("--mm-connection-color", "#cbd5e1");
-            root.style.setProperty("--mm-highlight", "#4dabf7");
-            root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.1)");
-            root.style.setProperty("--mm-toolbar-bg", "rgba(248, 250, 252, 0.95)");
-            root.style.setProperty("--mm-modal-bg", "#ffffff");
-            root.style.setProperty("--mm-modal-border", "#e2e8f0");
-            root.style.setProperty("--mm-primary-dark", "");
-            root.style.setProperty("--mm-border-dark", "");
+            root.style.setProperty("--mm-container-bg", "#ffffff", "important");
+            root.style.setProperty("--mm-bg", "#f8fafc", "important");
+            root.style.setProperty("--mm-text", "#1e293b", "important");
+            root.style.setProperty("--mm-node-bg", "#ffffff", "important");
+            root.style.setProperty("--mm-node-text", "#000000", "important");
+            root.style.setProperty("--mm-node-border-color", "#e2e8f0", "important");
+            root.style.setProperty("--mm-description-bg", "#f8fafc", "important");
+            root.style.setProperty("--mm-description-text", "#64748b", "important");
+            root.style.setProperty("--mm-primary", "#4dabf7", "important");
+            root.style.setProperty("--mm-primary-hover", "#339af7", "important");
+            root.style.setProperty("--mm-primary-light", "rgba(77, 171, 247, 0.1)", "important");
+            root.style.setProperty("--mm-border", "#e2e8f0", "important");
+            root.style.setProperty("--mm-border-light", "#f1f5f9", "important");
+            root.style.setProperty("--mm-connection-color", "#cbd5e1", "important");
+            root.style.setProperty("--mm-highlight", "#4dabf7", "important");
+            root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.1)", "important");
+            root.style.setProperty("--mm-toolbar-bg", "rgba(248, 250, 252, 0.95)", "important");
+            root.style.setProperty("--mm-modal-bg", "#ffffff", "important");
+            root.style.setProperty("--mm-modal-border", "#e2e8f0", "important");
+            root.style.setProperty("--mm-primary-dark", "", "important");
+            root.style.setProperty("--mm-border-dark", "", "important");
             // Update canvas background
             this.container.style.backgroundColor = "#ffffff";
             this.container.style.color = "#1e293b";

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -295,13 +295,60 @@ export const createButton = (
 
 // Helper: extract a solid CSS color from a background value
 export const extractSolidColor = (bg: string): string | null => {
-	const match = bg.match(/#[0-9a-f]{3,6}|rgb(a?)\([^)]+\)/i);
-	return match ? match[0] : null;
+        const match = bg.match(/#[0-9a-f]{3,6}|rgb(a?)\([^)]+\)/i);
+        return match ? match[0] : null;
+};
+
+// Force default MindViz CSS variables on the :root element
+export const enforceCssVars = (): void => {
+        if (typeof document === 'undefined') return;
+        const root = document.documentElement;
+        if (root.hasAttribute('data-mm-vars-injected')) return;
+        root.setAttribute('data-mm-vars-injected', 'true');
+
+        const vars: Record<string, string> = {
+                '--mm-primary': '#4dabf7',
+                '--mm-primary-hover': '#339af7',
+                '--mm-primary-light': '#e3f2fd',
+                '--mm-primary-dark': '#1976d2',
+                '--mm-secondary': '#6c757d',
+                '--mm-accent': '#ff9800',
+                '--mm-success': '#28a745',
+                '--mm-warning': '#ffc107',
+                '--mm-danger': '#ff6b6b',
+                '--mm-danger-hover': '#c82333',
+                '--mm-bg': '#ffffff',
+                '--mm-bg-secondary': '#f8f9fa',
+                '--mm-bg-tertiary': '#e9ecef',
+                '--mm-text': '#495057',
+                '--mm-text-secondary': '#6c757d',
+                '--mm-text-light': '#adb5bd',
+                '--mm-text-dark': '#212529',
+                '--mm-node-text': '#000000',
+                '--mm-border': '#e9ecef',
+                '--mm-border-light': '#f1f3f4',
+                '--mm-input-bg': '#ffffff',
+                '--mm-input-text': '#495057',
+                '--mm-input-border': '#e9ecef',
+                '--mm-input-focus': '#4dabf7',
+                '--mm-toolbar-bg': 'rgba(248, 250, 252, 0.95)',
+                '--mm-grid-color': 'rgba(200, 200, 200, 0.3)',
+                '--mm-grid-major-color': 'rgba(150, 150, 150, 0.5)',
+                '--mm-connection-color': '#ced4da',
+                '--mm-modal-bg': '#ffffff',
+                '--mm-modal-text': '#2d3436',
+                '--mm-modal-border': '#e0e0e0'
+        };
+
+        for (const [key, value] of Object.entries(vars)) {
+                root.style.setProperty(key, value, 'important');
+        }
 };
 
 // Global CSS animations
 export const injectGlobalStyles = () => {
-	const style = document.createElement('style');
+        enforceCssVars();
+        const style = document.createElement('style');
 	style.textContent = `
 		@keyframes ripple {
 			0% {

--- a/src/visualMindmap.ts
+++ b/src/visualMindmap.ts
@@ -1933,27 +1933,27 @@ class VisualMindMap {
     
     if (this.theme === 'dark') {
       // Dark theme colors
-      root.style.setProperty("--mm-container-bg", "#0f172a");
-      root.style.setProperty("--mm-bg", "#1e293b");
-      root.style.setProperty("--mm-text", "#f1f5f9");
-      root.style.setProperty("--mm-node-bg", "#334155");
-      root.style.setProperty("--mm-node-text", "#ffffff");
-      root.style.setProperty("--mm-node-border-color", "#475569");
-      root.style.setProperty("--mm-description-bg", "#1e293b");
-      root.style.setProperty("--mm-description-text", "#cbd5e1");
-      root.style.setProperty("--mm-primary", "#60a5fa");
-      root.style.setProperty("--mm-primary-hover", "#3b82f6");
-      root.style.setProperty("--mm-primary-light", "rgba(96, 165, 250, 0.1)");
-      root.style.setProperty("--mm-border", "#475569");
-      root.style.setProperty("--mm-border-light", "#374151");
-      root.style.setProperty("--mm-connection-color", "#64748b");
-      root.style.setProperty("--mm-highlight", "#60a5fa");
-      root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.4)");
-      root.style.setProperty("--mm-toolbar-bg", "rgba(30, 41, 59, 0.95)");
-      root.style.setProperty("--mm-modal-bg", "#1e293b");
-      root.style.setProperty("--mm-modal-border", "#475569");
-      root.style.setProperty("--mm-primary-dark", "#4dabf740");
-      root.style.setProperty("--mm-border-dark", "#5e5e5e");
+      root.style.setProperty("--mm-container-bg", "#0f172a", "important");
+      root.style.setProperty("--mm-bg", "#1e293b", "important");
+      root.style.setProperty("--mm-text", "#f1f5f9", "important");
+      root.style.setProperty("--mm-node-bg", "#334155", "important");
+      root.style.setProperty("--mm-node-text", "#ffffff", "important");
+      root.style.setProperty("--mm-node-border-color", "#475569", "important");
+      root.style.setProperty("--mm-description-bg", "#1e293b", "important");
+      root.style.setProperty("--mm-description-text", "#cbd5e1", "important");
+      root.style.setProperty("--mm-primary", "#60a5fa", "important");
+      root.style.setProperty("--mm-primary-hover", "#3b82f6", "important");
+      root.style.setProperty("--mm-primary-light", "rgba(96, 165, 250, 0.1)", "important");
+      root.style.setProperty("--mm-border", "#475569", "important");
+      root.style.setProperty("--mm-border-light", "#374151", "important");
+      root.style.setProperty("--mm-connection-color", "#64748b", "important");
+      root.style.setProperty("--mm-highlight", "#60a5fa", "important");
+      root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.4)", "important");
+      root.style.setProperty("--mm-toolbar-bg", "rgba(30, 41, 59, 0.95)", "important");
+      root.style.setProperty("--mm-modal-bg", "#1e293b", "important");
+      root.style.setProperty("--mm-modal-border", "#475569", "important");
+      root.style.setProperty("--mm-primary-dark", "#4dabf740", "important");
+      root.style.setProperty("--mm-border-dark", "#5e5e5e", "important");
       
       // Update canvas background
       this.container.style.backgroundColor = "#0f172a";
@@ -1967,27 +1967,27 @@ class VisualMindMap {
       }
     } else {
       // Light theme colors
-      root.style.setProperty("--mm-container-bg", "#ffffff");
-      root.style.setProperty("--mm-bg", "#f8fafc");
-      root.style.setProperty("--mm-text", "#1e293b");
-      root.style.setProperty("--mm-node-bg", "#ffffff");
-      root.style.setProperty("--mm-node-text", "#000000");
-      root.style.setProperty("--mm-node-border-color", "#e2e8f0");
-      root.style.setProperty("--mm-description-bg", "#f8fafc");
-      root.style.setProperty("--mm-description-text", "#64748b");
-      root.style.setProperty("--mm-primary", "#4dabf7");
-      root.style.setProperty("--mm-primary-hover", "#339af7");
-      root.style.setProperty("--mm-primary-light", "rgba(77, 171, 247, 0.1)");
-      root.style.setProperty("--mm-border", "#e2e8f0");
-      root.style.setProperty("--mm-border-light", "#f1f5f9");
-      root.style.setProperty("--mm-connection-color", "#cbd5e1");
-      root.style.setProperty("--mm-highlight", "#4dabf7");
-      root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.1)");
-      root.style.setProperty("--mm-toolbar-bg", "rgba(248, 250, 252, 0.95)");
-      root.style.setProperty("--mm-modal-bg", "#ffffff");
-      root.style.setProperty("--mm-modal-border", "#e2e8f0");
-      root.style.setProperty("--mm-primary-dark", "");
-      root.style.setProperty("--mm-border-dark", "");
+      root.style.setProperty("--mm-container-bg", "#ffffff", "important");
+      root.style.setProperty("--mm-bg", "#f8fafc", "important");
+      root.style.setProperty("--mm-text", "#1e293b", "important");
+      root.style.setProperty("--mm-node-bg", "#ffffff", "important");
+      root.style.setProperty("--mm-node-text", "#000000", "important");
+      root.style.setProperty("--mm-node-border-color", "#e2e8f0", "important");
+      root.style.setProperty("--mm-description-bg", "#f8fafc", "important");
+      root.style.setProperty("--mm-description-text", "#64748b", "important");
+      root.style.setProperty("--mm-primary", "#4dabf7", "important");
+      root.style.setProperty("--mm-primary-hover", "#339af7", "important");
+      root.style.setProperty("--mm-primary-light", "rgba(77, 171, 247, 0.1)", "important");
+      root.style.setProperty("--mm-border", "#e2e8f0", "important");
+      root.style.setProperty("--mm-border-light", "#f1f5f9", "important");
+      root.style.setProperty("--mm-connection-color", "#cbd5e1", "important");
+      root.style.setProperty("--mm-highlight", "#4dabf7", "important");
+      root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.1)", "important");
+      root.style.setProperty("--mm-toolbar-bg", "rgba(248, 250, 252, 0.95)", "important");
+      root.style.setProperty("--mm-modal-bg", "#ffffff", "important");
+      root.style.setProperty("--mm-modal-border", "#e2e8f0", "important");
+      root.style.setProperty("--mm-primary-dark", "", "important");
+      root.style.setProperty("--mm-border-dark", "", "important");
       
       // Update canvas background
       this.container.style.backgroundColor = "#ffffff";


### PR DESCRIPTION
## Summary
- force default CSS variables into `:root` using new `enforceCssVars`
- call `enforceCssVars` when injecting global styles
- ensure theme toggling applies CSS variables with `!important`

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6878dc5aebf883259f1fef21dc73d1da