### PR TITLE
Improve theme colors

### DIFF
--- a/dist/Toolbar.js
+++ b/dist/Toolbar.js
@@ -362,10 +362,14 @@ function createToolbar(vmm) {
     // Helper function to update button active states
     function updateButtonActiveState(button, isActive) {
         if (isActive) {
-            button.style.background = `linear-gradient(135deg, ${styles_1.CSS_VARS.primary}, ${styles_1.CSS_VARS.primaryHover})`;
-            button.style.borderColor = styles_1.CSS_VARS.primary;
+            const useSuccess = vmm['theme'] === 'light';
+            const start = useSuccess ? styles_1.CSS_VARS.success : styles_1.CSS_VARS.primary;
+            const end = useSuccess ? '#198754' : styles_1.CSS_VARS.primaryHover;
+            button.style.background = `linear-gradient(135deg, ${start}, ${end})`;
+            button.style.borderColor = start;
             button.style.color = '#ffffff';
-            button.style.boxShadow = "0 4px 12px rgba(77, 171, 247, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.2)";
+            const shadowColor = useSuccess ? 'rgba(40, 167, 69, 0.3)' : 'rgba(77, 171, 247, 0.3)';
+            button.style.boxShadow = `0 4px 12px ${shadowColor}, inset 0 1px 0 rgba(255, 255, 255, 0.2)`;
             button.style.transform = "translateY(-1px)";
             const svg = button.querySelector("svg");
             if (svg) {
@@ -836,6 +840,13 @@ function createToolbar(vmm) {
             svg.style.stroke = e.detail === false ? "currentColor" : "#4dabf7";
         }
         updateButtonActiveState(addConnectionBtn, e.detail !== false);
+    });
+    // Update active button colors when theme changes
+    vmm['container'].addEventListener('themeChanged', () => {
+        updateButtonActiveState(dragModeBtn, vmm['draggingMode']);
+        updateButtonActiveState(addConnectionBtn, vmm['connectionModeActive']);
+        updateButtonActiveState(gridToggleBtn, vmm['gridVisible']);
+        updateButtonActiveState(snapToggleBtn, vmm['gridEnabled']);
     });
     return toolbar;
 }

--- a/dist/visualMindmap.js
+++ b/dist/visualMindmap.js
@@ -1737,31 +1737,31 @@ class VisualMindMap {
         const root = document.documentElement;
         root.setAttribute('data-theme', this.theme);
         if (this.theme === 'dark') {
-            // Dark theme colors
-            root.style.setProperty("--mm-container-bg", "#0f172a", "important");
-            root.style.setProperty("--mm-bg", "#1e293b", "important");
-            root.style.setProperty("--mm-text", "#f1f5f9", "important");
-            root.style.setProperty("--mm-node-bg", "#334155", "important");
+            // Dark theme colors with stronger contrast
+            root.style.setProperty("--mm-container-bg", "#0b0d10", "important");
+            root.style.setProperty("--mm-bg", "#12171f", "important");
+            root.style.setProperty("--mm-text", "#f5f5f5", "important");
+            root.style.setProperty("--mm-node-bg", "#1c2128", "important");
             root.style.setProperty("--mm-node-text", "#ffffff", "important");
-            root.style.setProperty("--mm-node-border-color", "#475569", "important");
-            root.style.setProperty("--mm-description-bg", "#1e293b", "important");
-            root.style.setProperty("--mm-description-text", "#cbd5e1", "important");
-            root.style.setProperty("--mm-primary", "#60a5fa", "important");
-            root.style.setProperty("--mm-primary-hover", "#3b82f6", "important");
-            root.style.setProperty("--mm-primary-light", "rgba(96, 165, 250, 0.1)", "important");
-            root.style.setProperty("--mm-border", "#475569", "important");
+            root.style.setProperty("--mm-node-border-color", "#2d333b", "important");
+            root.style.setProperty("--mm-description-bg", "#12171f", "important");
+            root.style.setProperty("--mm-description-text", "#d1d5db", "important");
+            root.style.setProperty("--mm-primary", "#3b82f6", "important");
+            root.style.setProperty("--mm-primary-hover", "#2563eb", "important");
+            root.style.setProperty("--mm-primary-light", "rgba(59, 130, 246, 0.15)", "important");
+            root.style.setProperty("--mm-border", "#2d333b", "important");
             root.style.setProperty("--mm-border-light", "#374151", "important");
-            root.style.setProperty("--mm-connection-color", "#64748b", "important");
-            root.style.setProperty("--mm-highlight", "#60a5fa", "important");
-            root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.4)", "important");
-            root.style.setProperty("--mm-toolbar-bg", "rgba(30, 41, 59, 0.95)", "important");
-            root.style.setProperty("--mm-modal-bg", "#1e293b", "important");
-            root.style.setProperty("--mm-modal-border", "#475569", "important");
-            root.style.setProperty("--mm-primary-dark", "#4dabf740", "important");
+            root.style.setProperty("--mm-connection-color", "#475569", "important");
+            root.style.setProperty("--mm-highlight", "#3b82f6", "important");
+            root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.6)", "important");
+            root.style.setProperty("--mm-toolbar-bg", "rgba(17, 24, 39, 0.95)", "important");
+            root.style.setProperty("--mm-modal-bg", "#1c2128", "important");
+            root.style.setProperty("--mm-modal-border", "#2d333b", "important");
+            root.style.setProperty("--mm-primary-dark", "#1e40af", "important");
             root.style.setProperty("--mm-border-dark", "#5e5e5e", "important");
             // Update canvas background
-            this.container.style.backgroundColor = "#0f172a";
-            this.container.style.color = "#f1f5f9";
+            this.container.style.backgroundColor = "#0b0d10";
+            this.container.style.color = "#f5f5f5";
             // Update canvas grid pattern for dark mode
             if (this.canvas) {
                 this.canvas.style.backgroundImage = `

--- a/src/Toolbar.ts
+++ b/src/Toolbar.ts
@@ -383,10 +383,14 @@ export function createToolbar(vmm: VisualMindMap): HTMLElement {
   // Helper function to update button active states
   function updateButtonActiveState(button: HTMLButtonElement, isActive: boolean) {
     if (isActive) {
-      button.style.background = `linear-gradient(135deg, ${CSS_VARS.primary}, ${CSS_VARS.primaryHover})`;
-      button.style.borderColor = CSS_VARS.primary;
+      const useSuccess = vmm['theme'] === 'light';
+      const start = useSuccess ? CSS_VARS.success : CSS_VARS.primary;
+      const end = useSuccess ? '#198754' : CSS_VARS.primaryHover;
+      button.style.background = `linear-gradient(135deg, ${start}, ${end})`;
+      button.style.borderColor = start;
       button.style.color = '#ffffff';
-      button.style.boxShadow = "0 4px 12px rgba(77, 171, 247, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.2)";
+      const shadowColor = useSuccess ? 'rgba(40, 167, 69, 0.3)' : 'rgba(77, 171, 247, 0.3)';
+      button.style.boxShadow = `0 4px 12px ${shadowColor}, inset 0 1px 0 rgba(255, 255, 255, 0.2)`;
       button.style.transform = "translateY(-1px)";
       const svg = button.querySelector("svg");
       if (svg) {
@@ -886,6 +890,14 @@ export function createToolbar(vmm: VisualMindMap): HTMLElement {
       svg.style.stroke = (e as CustomEvent).detail === false ? "currentColor" : "#4dabf7";
     }
     updateButtonActiveState(addConnectionBtn, (e as CustomEvent).detail !== false);
+  });
+
+  // Update active button colors when theme changes
+  vmm['container'].addEventListener('themeChanged', () => {
+    updateButtonActiveState(dragModeBtn, vmm['draggingMode']);
+    updateButtonActiveState(addConnectionBtn, vmm['connectionModeActive']);
+    updateButtonActiveState(gridToggleBtn, vmm['gridVisible']);
+    updateButtonActiveState(snapToggleBtn, vmm['gridEnabled']);
   });
 
   return toolbar;

--- a/src/visualMindmap.ts
+++ b/src/visualMindmap.ts
@@ -1932,32 +1932,32 @@ class VisualMindMap {
     root.setAttribute('data-theme', this.theme);
     
     if (this.theme === 'dark') {
-      // Dark theme colors
-      root.style.setProperty("--mm-container-bg", "#0f172a", "important");
-      root.style.setProperty("--mm-bg", "#1e293b", "important");
-      root.style.setProperty("--mm-text", "#f1f5f9", "important");
-      root.style.setProperty("--mm-node-bg", "#334155", "important");
+      // Dark theme colors with stronger contrast
+      root.style.setProperty("--mm-container-bg", "#0b0d10", "important");
+      root.style.setProperty("--mm-bg", "#12171f", "important");
+      root.style.setProperty("--mm-text", "#f5f5f5", "important");
+      root.style.setProperty("--mm-node-bg", "#1c2128", "important");
       root.style.setProperty("--mm-node-text", "#ffffff", "important");
-      root.style.setProperty("--mm-node-border-color", "#475569", "important");
-      root.style.setProperty("--mm-description-bg", "#1e293b", "important");
-      root.style.setProperty("--mm-description-text", "#cbd5e1", "important");
-      root.style.setProperty("--mm-primary", "#60a5fa", "important");
-      root.style.setProperty("--mm-primary-hover", "#3b82f6", "important");
-      root.style.setProperty("--mm-primary-light", "rgba(96, 165, 250, 0.1)", "important");
-      root.style.setProperty("--mm-border", "#475569", "important");
+      root.style.setProperty("--mm-node-border-color", "#2d333b", "important");
+      root.style.setProperty("--mm-description-bg", "#12171f", "important");
+      root.style.setProperty("--mm-description-text", "#d1d5db", "important");
+      root.style.setProperty("--mm-primary", "#3b82f6", "important");
+      root.style.setProperty("--mm-primary-hover", "#2563eb", "important");
+      root.style.setProperty("--mm-primary-light", "rgba(59, 130, 246, 0.15)", "important");
+      root.style.setProperty("--mm-border", "#2d333b", "important");
       root.style.setProperty("--mm-border-light", "#374151", "important");
-      root.style.setProperty("--mm-connection-color", "#64748b", "important");
-      root.style.setProperty("--mm-highlight", "#60a5fa", "important");
-      root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.4)", "important");
-      root.style.setProperty("--mm-toolbar-bg", "rgba(30, 41, 59, 0.95)", "important");
-      root.style.setProperty("--mm-modal-bg", "#1e293b", "important");
-      root.style.setProperty("--mm-modal-border", "#475569", "important");
-      root.style.setProperty("--mm-primary-dark", "#4dabf740", "important");
+      root.style.setProperty("--mm-connection-color", "#475569", "important");
+      root.style.setProperty("--mm-highlight", "#3b82f6", "important");
+      root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.6)", "important");
+      root.style.setProperty("--mm-toolbar-bg", "rgba(17, 24, 39, 0.95)", "important");
+      root.style.setProperty("--mm-modal-bg", "#1c2128", "important");
+      root.style.setProperty("--mm-modal-border", "#2d333b", "important");
+      root.style.setProperty("--mm-primary-dark", "#1e40af", "important");
       root.style.setProperty("--mm-border-dark", "#5e5e5e", "important");
       
       // Update canvas background
-      this.container.style.backgroundColor = "#0f172a";
-      this.container.style.color = "#f1f5f9";
+      this.container.style.backgroundColor = "#0b0d10";
+      this.container.style.color = "#f5f5f5";
       
       // Update canvas grid pattern for dark mode
       if (this.canvas) {

--- a/styles.css
+++ b/styles.css
@@ -11,12 +11,12 @@
 }
 
 :root[data-theme="dark"] {
-    --mm-bg: #1a1a1a;
-    --mm-text: #e0e0e0;
-    --mm-border: #333333;
-    --mm-node-bg: #2d2d2d;
-    --mm-node-border-color: #404040;
-    --mm-node-text: #e0e0e0;
+    --mm-bg: #12171f;
+    --mm-text: #f5f5f5;
+    --mm-border: #2d333b;
+    --mm-node-bg: #1c2128;
+    --mm-node-border-color: #333333;
+    --mm-node-text: #f5f5f5;
 }
 
 /* Enhanced selection styles */
@@ -298,13 +298,13 @@ body, .mindnode, .connection, .toolbar-button, .sidebar-menu-item {
 
 /* Dark mode support */
 :root[data-theme="dark"] .neumorphic-effect {
-    background: linear-gradient(145deg, #2d2d2d, #1a1a1a);
+    background: linear-gradient(145deg, #1f1f1f, #121212);
     box-shadow:
-        20px 20px 60px #0d0d0d,
-        -20px -20px 60px #333333;
+        20px 20px 60px #000000,
+        -20px -20px 60px #2a2a2a;
 }
 
 :root[data-theme="dark"] .glass-effect {
-    background: rgba(0, 0, 0, 0.2);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.15);
 }


### PR DESCRIPTION
## Summary
- dark theme uses deeper backgrounds and brighter text for better contrast
- light theme toolbar buttons highlight in green
- update styles for neumorphic and glass effects
- refresh compiled output

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878e1b7422c832587f819edbe9c3ab8