### PR TITLE
Improve dark mode gradient and add description on new nodes

### DIFF
--- a/dist/Modal.d.ts
+++ b/dist/Modal.d.ts
@@ -6,3 +6,7 @@ export declare function showStyleModal(defaultText: string, defaultBg: string, d
     shape: string;
 } | null>;
 export declare function showInputModal(titleText: string, labelText: string, defaultValue?: string): Promise<string | null>;
+export declare function showAddNodeModal(titleText: string, defaultLabel?: string, defaultDescription?: string, labelPlaceholder?: string): Promise<{
+    label: string;
+    description: string;
+} | null>;

--- a/dist/Modal.js
+++ b/dist/Modal.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.showStyleModal = showStyleModal;
 exports.showInputModal = showInputModal;
+exports.showAddNodeModal = showAddNodeModal;
 const styles_1 = require("./styles");
 const TextEditor_1 = require("./TextEditor");
 function showStyleModal(defaultText, defaultBg, defaultDesc, defaultImageUrl = "", defaultShape = "rectangle") {
@@ -273,5 +274,99 @@ function showInputModal(titleText, labelText, defaultValue = "") {
         overlay.appendChild(modal);
         document.body.appendChild(overlay);
         input.focus();
+    });
+}
+function showAddNodeModal(titleText, defaultLabel = "", defaultDescription = "", labelPlaceholder = "Node Label") {
+    return new Promise(resolve => {
+        const overlay = (0, styles_1.createBaseElement)('div', {
+            position: 'fixed',
+            top: '0',
+            left: '0',
+            width: '100vw',
+            height: '100vh',
+            background: 'rgba(0,0,0,0.6)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: '10000',
+            backdropFilter: 'blur(8px)'
+        });
+        const modal = (0, styles_1.createBaseElement)('div', {
+            background: styles_1.CSS_VARS.background,
+            padding: '24px',
+            borderRadius: '12px',
+            boxShadow: '0 12px 24px rgba(0,0,0,0.2)',
+            width: '90%',
+            maxWidth: '400px'
+        });
+        const header = (0, styles_1.createBaseElement)('h3', {
+            margin: '0 0 16px',
+            fontSize: '20px',
+            color: styles_1.CSS_VARS.text
+        });
+        header.textContent = titleText;
+        const labelInput = (0, styles_1.createInput)();
+        labelInput.value = defaultLabel;
+        labelInput.placeholder = labelPlaceholder;
+        labelInput.style.width = '100%';
+        labelInput.style.padding = '8px';
+        labelInput.style.marginBottom = '16px';
+        const descInput = (0, styles_1.createBaseElement)('textarea', {
+            width: '100%',
+            padding: `${styles_1.CSS_VARS.spacing.lg} ${styles_1.CSS_VARS.spacing.xl}`,
+            border: `2px solid ${styles_1.CSS_VARS['input-border']}`,
+            borderRadius: styles_1.CSS_VARS.radius.md,
+            fontSize: '14px',
+            fontWeight: '500',
+            transition: `all ${styles_1.CSS_VARS.transition.normal}`,
+            background: styles_1.CSS_VARS['input-bg'],
+            color: styles_1.CSS_VARS['input-text'],
+            outline: 'none',
+            boxShadow: styles_1.CSS_VARS.shadow.xs,
+            resize: 'vertical',
+            marginBottom: '16px'
+        });
+        descInput.rows = 3;
+        descInput.value = defaultDescription;
+        descInput.addEventListener('focus', () => {
+            descInput.style.borderColor = styles_1.CSS_VARS['input-focus'];
+            descInput.style.boxShadow = `${styles_1.CSS_VARS.shadow.sm}, 0 0 0 3px rgba(77, 171, 247, 0.1)`;
+            descInput.style.transform = 'translateY(-1px)';
+        });
+        descInput.addEventListener('blur', () => {
+            descInput.style.borderColor = styles_1.CSS_VARS['input-border'];
+            descInput.style.boxShadow = styles_1.CSS_VARS.shadow.xs;
+            descInput.style.transform = 'translateY(0)';
+        });
+        const btnGroup = (0, styles_1.createBaseElement)('div', {
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '8px'
+        });
+        const cancelBtn = (0, styles_1.createButton)('secondary');
+        cancelBtn.textContent = 'Cancel';
+        cancelBtn.addEventListener('click', () => { overlay.remove(); resolve(null); });
+        const okBtn = (0, styles_1.createButton)('primary');
+        okBtn.textContent = 'Add';
+        okBtn.addEventListener('click', () => {
+            const label = labelInput.value.trim();
+            const description = descInput.value.trim();
+            overlay.remove();
+            if (!label) {
+                resolve(null);
+            }
+            else {
+                resolve({ label, description });
+            }
+        });
+        btnGroup.appendChild(cancelBtn);
+        btnGroup.appendChild(okBtn);
+        modal.appendChild(header);
+        modal.appendChild(labelInput);
+        modal.appendChild(descInput);
+        modal.appendChild(btnGroup);
+        overlay.appendChild(modal);
+        document.body.appendChild(overlay);
+        labelInput.focus();
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.showInputModal = exports.showStyleModal = exports.createTextEditor = exports.TextEditor = exports.VisualWhiteboard = exports.Whiteboard = exports.VisualMindMap = exports.MindNode = exports.MindMap = void 0;
+exports.showAddNodeModal = exports.showInputModal = exports.showStyleModal = exports.createTextEditor = exports.TextEditor = exports.VisualWhiteboard = exports.Whiteboard = exports.VisualMindMap = exports.MindNode = exports.MindMap = void 0;
 // filepath: c:\Users\lsche\Documents\vscode\projects\mindviz\src\index.ts
 var mindmap_1 = require("./mindmap");
 Object.defineProperty(exports, "MindMap", { enumerable: true, get: function () { return mindmap_1.MindMap; } });
@@ -17,3 +17,4 @@ Object.defineProperty(exports, "createTextEditor", { enumerable: true, get: func
 var Modal_1 = require("./Modal");
 Object.defineProperty(exports, "showStyleModal", { enumerable: true, get: function () { return Modal_1.showStyleModal; } });
 Object.defineProperty(exports, "showInputModal", { enumerable: true, get: function () { return Modal_1.showInputModal; } });
+Object.defineProperty(exports, "showAddNodeModal", { enumerable: true, get: function () { return Modal_1.showAddNodeModal; } });

--- a/dist/visualMindmap.d.ts
+++ b/dist/visualMindmap.d.ts
@@ -57,7 +57,6 @@ declare class VisualMindMap {
     private isValidColor;
     private updateMindNodeBackground;
     private updateMindNodeDescription;
-    private showModal;
     private drawLine;
     private handleConnectionClick;
     private ensureDefs;

--- a/dist/visualMindmap.js
+++ b/dist/visualMindmap.js
@@ -601,17 +601,19 @@ class VisualMindMap {
             e.stopPropagation();
             const parentId = parseInt(MindNodeDiv.dataset.mindNodeId);
             this.recordSnapshot(); // record state before addition
-            const newLabel = await this.showModal("Enter label for new child MindNode:");
-            if (newLabel) {
+            const result = await (0, Modal_1.showAddNodeModal)("Add Child Node");
+            if (result) {
                 const parentNode = this.findMindNode(parentId);
                 if (!parentNode)
                     return;
-                const newNode = this.mindMap.addMindNode(parentId, newLabel);
+                const newNode = this.mindMap.addMindNode(parentId, result.label);
+                newNode.description = result.description;
                 // Broadcast node addition
                 this.broadcastOperation({
                     type: 'node_add',
                     parentId: parentId,
-                    label: newLabel,
+                    label: result.label,
+                    description: result.description,
                     nodeId: newNode.id,
                     timestamp: Date.now()
                 });
@@ -711,74 +713,6 @@ class VisualMindMap {
             return false;
         }
         return traverse(this.mindMap.root);
-    }
-    // NEW: Custom modal to replace browser prompt
-    showModal(promptText, defaultText = "") {
-        // If in test mode, bypass the modal and return the preset reply.
-        if (window.__TEST_MODE__) {
-            return Promise.resolve(window.__TEST_PROMPT_REPLY__ || null);
-        }
-        return new Promise((resolve) => {
-            const modalOverlay = document.createElement("div");
-            Object.assign(modalOverlay.style, {
-                position: "fixed",
-                top: "0",
-                left: "0",
-                width: "100vw",
-                height: "100vh",
-                backgroundColor: "rgba(0,0,0,0.5)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                zIndex: "2147483647" // updated z-index for fullscreen modals
-            });
-            const modalContainer = document.createElement("div");
-            Object.assign(modalContainer.style, {
-                background: "#fff",
-                padding: "20px",
-                borderRadius: "8px",
-                boxShadow: "0 2px 10px rgba(0,0,0,0.3)",
-                minWidth: "200px",
-                zIndex: "10001" // above modal overlay
-            });
-            const promptEl = document.createElement("div");
-            promptEl.innerText = promptText;
-            promptEl.style.marginBottom = "10px";
-            modalContainer.appendChild(promptEl);
-            const inputEl = document.createElement("input");
-            inputEl.type = "text";
-            inputEl.value = defaultText;
-            inputEl.style.width = "100%";
-            inputEl.style.marginBottom = "10px";
-            modalContainer.appendChild(inputEl);
-            const buttonContainer = document.createElement("div");
-            const okButton = document.createElement("button");
-            okButton.innerText = "OK";
-            okButton.style.marginRight = "10px";
-            const cancelButton = document.createElement("button");
-            cancelButton.innerText = "Cancel";
-            buttonContainer.appendChild(okButton);
-            buttonContainer.appendChild(cancelButton);
-            modalContainer.appendChild(buttonContainer);
-            modalOverlay.appendChild(modalContainer);
-            const parent = document.fullscreenElement || this.container;
-            parent.appendChild(modalOverlay);
-            modalOverlay.addEventListener("click", (e) => {
-                if (e.target === modalOverlay) {
-                    modalOverlay.remove();
-                    resolve(null);
-                }
-            });
-            okButton.addEventListener("click", () => {
-                const value = inputEl.value;
-                modalOverlay.remove();
-                resolve(value);
-            });
-            cancelButton.addEventListener("click", () => {
-                modalOverlay.remove();
-                resolve(null);
-            });
-        });
     }
     // Modified drawLine method:
     drawLine(parent, child) {

--- a/src/Modal.ts
+++ b/src/Modal.ts
@@ -290,3 +290,114 @@ export function showInputModal(
     input.focus();
   });
 }
+
+export function showAddNodeModal(
+  titleText: string,
+  defaultLabel: string = "",
+  defaultDescription: string = "",
+  labelPlaceholder: string = "Node Label"
+): Promise<{ label: string; description: string } | null> {
+  return new Promise(resolve => {
+    const overlay = createBaseElement<HTMLDivElement>('div', {
+      position: 'fixed',
+      top: '0',
+      left: '0',
+      width: '100vw',
+      height: '100vh',
+      background: 'rgba(0,0,0,0.6)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: '10000',
+      backdropFilter: 'blur(8px)'
+    });
+
+    const modal = createBaseElement<HTMLDivElement>('div', {
+      background: CSS_VARS.background,
+      padding: '24px',
+      borderRadius: '12px',
+      boxShadow: '0 12px 24px rgba(0,0,0,0.2)',
+      width: '90%',
+      maxWidth: '400px'
+    });
+
+    const header = createBaseElement<HTMLHeadingElement>('h3', {
+      margin: '0 0 16px',
+      fontSize: '20px',
+      color: CSS_VARS.text
+    });
+    header.textContent = titleText;
+
+    const labelInput = createInput();
+    labelInput.value = defaultLabel;
+    labelInput.placeholder = labelPlaceholder;
+    labelInput.style.width = '100%';
+    labelInput.style.padding = '8px';
+    labelInput.style.marginBottom = '16px';
+
+    const descInput = createBaseElement<HTMLTextAreaElement>('textarea', {
+      width: '100%',
+      padding: `${CSS_VARS.spacing.lg} ${CSS_VARS.spacing.xl}`,
+      border: `2px solid ${CSS_VARS['input-border']}`,
+      borderRadius: CSS_VARS.radius.md,
+      fontSize: '14px',
+      fontWeight: '500',
+      transition: `all ${CSS_VARS.transition.normal}`,
+      background: CSS_VARS['input-bg'],
+      color: CSS_VARS['input-text'],
+      outline: 'none',
+      boxShadow: CSS_VARS.shadow.xs,
+      resize: 'vertical',
+      marginBottom: '16px'
+    });
+
+    descInput.rows = 3;
+    descInput.value = defaultDescription;
+
+    descInput.addEventListener('focus', () => {
+      descInput.style.borderColor = CSS_VARS['input-focus'];
+      descInput.style.boxShadow = `${CSS_VARS.shadow.sm}, 0 0 0 3px rgba(77, 171, 247, 0.1)`;
+      descInput.style.transform = 'translateY(-1px)';
+    });
+
+    descInput.addEventListener('blur', () => {
+      descInput.style.borderColor = CSS_VARS['input-border'];
+      descInput.style.boxShadow = CSS_VARS.shadow.xs;
+      descInput.style.transform = 'translateY(0)';
+    });
+
+    const btnGroup = createBaseElement<HTMLDivElement>('div', {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      gap: '8px'
+    });
+
+    const cancelBtn = createButton('secondary');
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => { overlay.remove(); resolve(null); });
+
+    const okBtn = createButton('primary');
+    okBtn.textContent = 'Add';
+    okBtn.addEventListener('click', () => {
+      const label = labelInput.value.trim();
+      const description = descInput.value.trim();
+      overlay.remove();
+      if (!label) {
+        resolve(null);
+      } else {
+        resolve({ label, description });
+      }
+    });
+
+    btnGroup.appendChild(cancelBtn);
+    btnGroup.appendChild(okBtn);
+
+    modal.appendChild(header);
+    modal.appendChild(labelInput);
+    modal.appendChild(descInput);
+    modal.appendChild(btnGroup);
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+    labelInput.focus();
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { VisualMindMap } from "./visualMindmap";
 export { Whiteboard } from "./whiteboard";
 export { VisualWhiteboard } from "./visualWhiteboard";
 export { TextEditor, createTextEditor } from "./TextEditor";
-export { showStyleModal, showInputModal } from "./Modal";
+export { showStyleModal, showInputModal, showAddNodeModal } from "./Modal";
 export type { WhiteboardItem, WhiteboardItemType } from "./whiteboard";
 export type { VisualOptions } from "./visualWhiteboard";
 export type { EventName, Listener } from "./whiteboard";

--- a/style.css
+++ b/style.css
@@ -16,6 +16,7 @@
     position: relative;
 }
 
+
 .mind-node::before {
     content: '';
     position: absolute;
@@ -28,6 +29,10 @@
     z-index: -1;
     opacity: 0;
     transition: opacity 0.3s ease;
+}
+
+:root[data-theme="dark"] .mind-node::before {
+    background: linear-gradient(45deg, var(--mm-primary-dark), var(--mm-primary));
 }
 
 .mind-node:hover::before {


### PR DESCRIPTION
## Summary
- tweak dark theme node highlight gradient
- add `showAddNodeModal` for consistent modal styling
- expose new modal in `index`
- use styled modal when adding child nodes
- build dist

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878ede776d88325910d7dd1e377066d