### PR TITLE
feat: theme-aware connection labels

### DIFF
--- a/dist/components/ConnectionLabel.js
+++ b/dist/components/ConnectionLabel.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ConnectionLabel = void 0;
+const styles_1 = require("../styles");
 class BaseComponent {
     constructor(tag = "div") {
         this.el = document.createElement(tag);
@@ -15,11 +16,13 @@ class ConnectionLabel extends BaseComponent {
         this.applyStyles({
             position: "absolute",
             transform: "translate(-50%, -50%)",
-            background: "rgba(255, 255, 255, 0.9)",
+            background: styles_1.CSS_VARS['connection-label-bg'],
+            color: styles_1.CSS_VARS['connection-label-text'],
             padding: "2px 6px",
-            borderRadius: "var(--border-radius, 4px)",
+            borderRadius: styles_1.CSS_VARS.radius.sm,
             fontSize: "12px",
-            pointerEvents: "none"
+            pointerEvents: "none",
+            transition: `background ${styles_1.CSS_VARS.transition.normal}, color ${styles_1.CSS_VARS.transition.normal}`
         });
         this.el.textContent = text;
         this.el.className = "connection-label";

--- a/dist/styles.d.ts
+++ b/dist/styles.d.ts
@@ -71,6 +71,8 @@ export declare const CSS_VARS: {
     'grid-color': string;
     'grid-major-color': string;
     'connection-color': string;
+    'connection-label-bg': string;
+    'connection-label-text': string;
     easing: {
         easeInOut: string;
         easeOut: string;

--- a/dist/styles.js
+++ b/dist/styles.js
@@ -85,6 +85,8 @@ exports.CSS_VARS = {
     'grid-color': 'var(--mm-grid-color, rgba(200, 200, 200, 0.3))',
     'grid-major-color': 'var(--mm-grid-major-color, rgba(150, 150, 150, 0.5))',
     'connection-color': 'var(--mm-connection-color, #ced4da)',
+    'connection-label-bg': 'var(--mm-connection-label-bg, rgba(255, 255, 255, 0.9))',
+    'connection-label-text': 'var(--mm-connection-label-text, var(--mm-text, #495057))',
     // Animation easing functions
     easing: {
         easeInOut: 'cubic-bezier(0.4, 0, 0.2, 1)',

--- a/dist/visualMindmap.js
+++ b/dist/visualMindmap.js
@@ -1701,6 +1701,8 @@ class VisualMindMap {
             root.style.setProperty("--mm-border", "#2d333b", "important");
             root.style.setProperty("--mm-border-light", "#374151", "important");
             root.style.setProperty("--mm-connection-color", "#475569", "important");
+            root.style.setProperty("--mm-connection-label-bg", "rgba(0, 0, 0, 0.7)", "important");
+            root.style.setProperty("--mm-connection-label-text", "#f5f5f5", "important");
             root.style.setProperty("--mm-highlight", "#3b82f6", "important");
             root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.6)", "important");
             root.style.setProperty("--mm-toolbar-bg", "rgba(17, 24, 39, 0.95)", "important");
@@ -1734,6 +1736,8 @@ class VisualMindMap {
             root.style.setProperty("--mm-border", "#e2e8f0", "important");
             root.style.setProperty("--mm-border-light", "#f1f5f9", "important");
             root.style.setProperty("--mm-connection-color", "#cbd5e1", "important");
+            root.style.setProperty("--mm-connection-label-bg", "rgba(255, 255, 255, 0.9)", "important");
+            root.style.setProperty("--mm-connection-label-text", "#1e293b", "important");
             root.style.setProperty("--mm-highlight", "#4dabf7", "important");
             root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.1)", "important");
             root.style.setProperty("--mm-toolbar-bg", "rgba(248, 250, 252, 0.95)", "important");

--- a/src/components/ConnectionLabel.ts
+++ b/src/components/ConnectionLabel.ts
@@ -1,3 +1,5 @@
+import { CSS_VARS } from "../styles";
+
 class BaseComponent {
   public el: HTMLElement;
   constructor(tag: string = "div") {
@@ -14,11 +16,13 @@ export class ConnectionLabel extends BaseComponent {
     this.applyStyles({
       position: "absolute",
       transform: "translate(-50%, -50%)",
-      background: "rgba(255, 255, 255, 0.9)",
+      background: CSS_VARS['connection-label-bg'],
+      color: CSS_VARS['connection-label-text'],
       padding: "2px 6px",
-      borderRadius: "var(--border-radius, 4px)",
+      borderRadius: CSS_VARS.radius.sm,
       fontSize: "12px",
-      pointerEvents: "none"
+      pointerEvents: "none",
+      transition: `background ${CSS_VARS.transition.normal}, color ${CSS_VARS.transition.normal}`
     });
     this.el.textContent = text;
     this.el.className = "connection-label";

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -95,6 +95,8 @@ export const CSS_VARS = {
         'grid-major-color': 'var(--mm-grid-major-color, rgba(150, 150, 150, 0.5))',
 
         'connection-color': 'var(--mm-connection-color, #ced4da)',
+        'connection-label-bg': 'var(--mm-connection-label-bg, rgba(255, 255, 255, 0.9))',
+        'connection-label-text': 'var(--mm-connection-label-text, var(--mm-text, #495057))',
 	
 	// Animation easing functions
 	easing: {

--- a/src/visualMindmap.ts
+++ b/src/visualMindmap.ts
@@ -1891,6 +1891,8 @@ class VisualMindMap {
       root.style.setProperty("--mm-border", "#2d333b", "important");
       root.style.setProperty("--mm-border-light", "#374151", "important");
       root.style.setProperty("--mm-connection-color", "#475569", "important");
+      root.style.setProperty("--mm-connection-label-bg", "rgba(0, 0, 0, 0.7)", "important");
+      root.style.setProperty("--mm-connection-label-text", "#f5f5f5", "important");
       root.style.setProperty("--mm-highlight", "#3b82f6", "important");
       root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.6)", "important");
       root.style.setProperty("--mm-toolbar-bg", "rgba(17, 24, 39, 0.95)", "important");
@@ -1925,6 +1927,8 @@ class VisualMindMap {
       root.style.setProperty("--mm-border", "#e2e8f0", "important");
       root.style.setProperty("--mm-border-light", "#f1f5f9", "important");
       root.style.setProperty("--mm-connection-color", "#cbd5e1", "important");
+      root.style.setProperty("--mm-connection-label-bg", "rgba(255, 255, 255, 0.9)", "important");
+      root.style.setProperty("--mm-connection-label-text", "#1e293b", "important");
       root.style.setProperty("--mm-highlight", "#4dabf7", "important");
       root.style.setProperty("--mm-shadow", "rgba(0, 0, 0, 0.1)", "important");
       root.style.setProperty("--mm-toolbar-bg", "rgba(248, 250, 252, 0.95)", "important");

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,8 @@
     --mm-node-bg: #ffffff;
     --mm-node-border-color: #e9ecef;
     --mm-node-text: #000000;
+    --mm-connection-label-bg: rgba(255, 255, 255, 0.9);
+    --mm-connection-label-text: var(--mm-text);
 }
 
 :root[data-theme="dark"] {
@@ -17,6 +19,8 @@
     --mm-node-bg: #000000;
     --mm-node-border-color: #1f1616;
     --mm-node-text: #ffffff;
+    --mm-connection-label-bg: rgba(0, 0, 0, 0.7);
+    --mm-connection-label-text: var(--mm-text);
 }
 
 /* Enhanced selection styles */


### PR DESCRIPTION
## Summary
- allow connection labels to follow light and dark themes via new CSS variables
- update ConnectionLabel component and theme toggle to use theme-aware styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689522c0f59883259cabf433204e330a